### PR TITLE
Mod_公共入口抽离配置修改, html-webpack-plugin chunksSortMode: 'dependency' 按照依赖…

### DIFF
--- a/build/dev.js
+++ b/build/dev.js
@@ -6,7 +6,7 @@ const webpackHotMiddleware = require('webpack-hot-middleware')
 const proxyMiddleware = require('http-proxy-middleware')
 const opn = require('opn')
 const config = require('../config')
-const webpackMerge = 	require('./conf.dev')
+const webpackMerge = require('./conf.dev')
 const baseWebpack =	require('./webpack.config')
 
 var app = express();

--- a/build/webpack.config.js
+++ b/build/webpack.config.js
@@ -14,32 +14,6 @@ const vueLoaderConfig = require('./vue-loader.conf')
 const isPro = process.env.NODE_ENV == 'production'
 
 const entries = require('../config/entries').entries
-// function createHappyPlugin(id, loaders) {
-//   console.log('id', id)
-//   return new HappyPack({
-//     id: id,
-//     loaders: loaders,
-//     threadPool: happyThreadPool,
-
-//     // disable happy caching with HAPPY_CACHE=0
-//     cache: true,
-
-//     // make happy more verbose with HAPPY_VERBOSE=1
-//     verbose: process.env.HAPPY_VERBOSE === '1',
-//   });
-// }
-
-// function getEntry(globPath) {
-//     var entries = {}, basename;
-//   glob.sync(globPath).forEach(function (entry) {
-//     basename = path.basename(entry, path.extname(entry));
-//     entries[basename] = [];
-//     // entries[basename].push(entry);
-//     entries[basename].push(entry);
-//   });
-//   return entries;
-// }
-// var entries = getEntry("./src/views/*/*.js"); // 获得入口js文件
 
 module.exports = {
   entry: entries,
@@ -82,14 +56,6 @@ module.exports = {
           // ]
         }
       },
-      // {
-      //   test: /\.ts$/,
-      //   loader: 'ts-loader',
-      //   options: {
-      //     // appendTsSuffixTo: [/\.vue$/],
-      //     transpileOnly: true
-      //   }
-      // },
       {
         test: /\.js|\.vue$/,
         exclude: /node_modules/,

--- a/codeStyle.md
+++ b/codeStyle.md
@@ -1,0 +1,63 @@
+## vue 文件
+
+### 1.组件/实例的选项顺序
+
+- name
+- extends / mixins
+- model / props / propsData
+- data / computed
+- watch / 生命周期钩子
+- methods
+
+### 2.元素特性的顺序
+
+- is
+- v-for / v-if / v-else-if / v-else / v-show / v-cloak
+- v-pre / v-once
+- id
+- ref / key / slot
+- v-model
+- v-on
+- v-html / v-text
+
+### 3.组件复用
+
+- 尽量避免组件的拷贝, 可增加组件扩展性或使用extends进行组件的扩展使用
+- 
+
+## 样式
+
+- 注意不要使用单组件或内部组件样式. 公用样式提取到sass文件中, 父组件可控制其子组件样式, 单不可使用其子组件样式
+(更新webpack后模块引入均采用异步实现, 若是使用的 class 来源于未加载组件, 则样式不可见)
+
+- 样式命名
+```
+布局(g): 以 g 为命名空间
+  例: .g-wrap , .g-header, .g-content.
+状态(s): 以 s 为命名空间, 表示动态的, 具有交互性质的状态
+  例: .s-active,  s-selected.
+工具(u): 以 u 为命名空间, 表示不耦合业务逻辑的, 可复用的工具
+  例: u-clearfix, u-ellipsis.
+组件(m/p): 
+  复用: 以 m 为命名空间, 表示可复用, 移植的组件模块
+    例: m-slider.
+  非复用: 以 p 为命名空间, 表示私有组件, 仅单一位置使用
+    例: p-format, p-sidebar
+钩子(j): 以 j 为命名空间, 表示特定给 JavaScript 调用的类名
+  例: j-request, j-open.
+```
+
+## js 文件
+- 遵循 eslint 常用配置(多使用 eslint 工具编写, 养成习惯)
+- 缩进采用 2 空格缩进
+- 分号结合框架, vue 风格为不使用分号
+- 变量定义尽量不要放在一行内
+```
+  let a = 10, b = 10
+  ->
+  let a = 10
+  let b = 10
+```
+- 函数定义空格 function fn () { ... }
+- 注释空格 var a = 10 // 解释
+- 模块末尾追加多余一行空行

--- a/config/bundle.config.json
+++ b/config/bundle.config.json
@@ -4,5 +4,6 @@
       "pages": ["index", "demo", "components"],
       "modules": ["vue", "vuex", "vue-router"]
     }
-  }
+  },
+  "provide": []
 }

--- a/config/entries.js
+++ b/config/entries.js
@@ -5,17 +5,12 @@ const libs = require('./index').libs
 function getEntry(globPath) {
   var entries = {}, basename;
   glob.sync(globPath).forEach(function (entry) {
-    basename = path.basename(entry, path.extname(entry));
-    entries[basename] = [];
-    // entries[basename].push(entry);
-    entries[basename].push(entry);
-  });
-  return entries;
+    basename = path.basename(entry, path.extname(entry))
+    entries[basename] = [entry]
+  })
+  return entries
 }
 const pageEntries = getEntry("./src/views/*/*.js"); // 获取对应 html 入口文件文件
-// var pageEntries = {
-// 	index: './src/views/index/index.js'
-// }
 const entries = {}
 
 for (let key in pageEntries) {

--- a/config/index.js
+++ b/config/index.js
@@ -17,19 +17,7 @@ module.exports = {
 		assetsPublicPath: '/',
 		productionSourceMap: false,
 		cacheBusting: true,
-    cssSourceMap: true,
-		chunks: [
-			// {
-			// 	node_module: true,
-			// 	name: 'vue',
-			// 	filename: 'vue.js',
-			// 	chunks: Infinity
-			// },
-			{
-				node_module: true,
-				name: 'vendor'
-			}
-		]
+    cssSourceMap: true
 	},
 	dev: {
 		env: require('./env.dev'),


### PR DESCRIPTION
…进行插入 script 标签不可靠, 顺序出现加载错误， 使用auto排序

script 插入排序为 manifest -> 依赖分离入口1 -> 依赖分离入口2 -> ... -> 该html文件对应入口文件